### PR TITLE
Mentioning to the plugin properties and updating examples

### DIFF
--- a/plugins/osgi_plugin.md
+++ b/plugins/osgi_plugin.md
@@ -132,7 +132,7 @@ Declarative Services descriptors can be written by hand, but the simplest way to
 ```
 Note that the annotations are pulled in as a `provided` scope dependency. This is because the annotations are for build-time processing only (step 3 of the scope selection process).
 
-Once the Declarative Services Annotations are available we can simply annotate the `ApplianceManagerApi` implementation type with the `@Component` annotation to register it as a component. Note that because the implementation directly implements an interface it will automatically be registered as an OSGi service using this interface. We also need to add all the required service properties [](#plugin-properties) to allow OSC to identify and correctly use this plugin. See [Security Manager Plugin Properties](sdn_controller_plugin.md#plugin-properties) and [SDN Controller Plugin Properties](sdn_controller_plugin.md#plugin-properties) for more details on the required properties for each of these plugin types.  
+Once the Declarative Services Annotations are available we can simply annotate the `ApplianceManagerApi` implementation type with the `@Component` annotation to register it as a component. Note that because the implementation directly implements an interface it will automatically be registered as an OSGi service using this interface. We also need to add all the required service properties to allow OSC to identify and correctly use this plugin. See [Security Manager Plugin Properties](sdn_controller_plugin.md#plugin-properties) and [SDN Controller Plugin Properties](sdn_controller_plugin.md#plugin-properties) for more details on the required properties for each of these plugin types.  
 
 
 ```java
@@ -164,8 +164,7 @@ Note that as of the current specification (Declarative Services 1.3) a component
 ### Startup and Shutdown
 Declarative Services components can only be activated when their mandatory dependencies are available. When a component becomes eligible for activation it is injected with all of its dependencies, however it may not yet be ready for use. Commonly components require some level of initialization after injection has finished. In Declarative Services this can be requested by annotating a startup method with @Activate, for example:
 ```java
-@Component(
-property={/*…*/})
+@Component(property={/*…*/})
 public class ExampleApplianceManager implements ApplianceManagerApi
 {
     @Activate

--- a/plugins/sdn_controller_plugin.md
+++ b/plugins/sdn_controller_plugin.md
@@ -22,4 +22,4 @@ Inspection hooks are used by OSC to create, update or delete traffic redirection
 These set of APIs comprises CRUD operations for inspection books.
 
 ### Plugin Properties
-In addition to the functionalities mentioned above, this SDK also specificies a set of required properties that must be provided when [registering the plugin implementation as an OSGi service](osgi_plugin.md#exposing-the-service-provided-by-the-plugin). These properties will be used by OSC to identify and correctly use the plugin.  For more details and the full list of required properties see the `javadoc` of the interface `org.osc.sdk.controller.api.SdnControllerApi` defined by this SDK.  
+In addition to the functionalities mentioned above, this SDK also specificies a set of required properties that must be provided when [registering the plugin implementation as an OSGi service](osgi_plugin.md#exposing-the-service-provided-by-the-plugin). These properties will be used by OSC to identify and correctly use the plugin.  For more details and the full list of required properties, see the `javadoc` of the interface `org.osc.sdk.controller.api.SdnControllerApi` defined by this SDK.  

--- a/plugins/security_mgr_plugin.md
+++ b/plugins/security_mgr_plugin.md
@@ -57,7 +57,7 @@ These APIs are used by OSC to retrieve domain information provided by the manage
 These APIs are used by OSC to retrieve policy information provided by the managers.  This set of APIs is optional. 
 
 ### Plugin Properties
-In addition to the functionalities mentioned above, this SDK also specificies a set of required properties that must be provided when [registering the plugin implementation as an OSGi service](osgi_plugin.md#exposing-the-service-provided-by-the-plugin). These properties will be used by OSC to identify and correctly use the plugin.  For more details and the full list of required properties see the `javadoc` of the interface `org.osc.sdk.manager.api.ApplianceManagerApi` defined by this SDK.
+In addition to the functionalities mentioned above, this SDK also specificies a set of required properties that must be provided when [registering the plugin implementation as an OSGi service](osgi_plugin.md#exposing-the-service-provided-by-the-plugin). These properties will be used by OSC to identify and correctly use the plugin.  For more details and the full list of required properties, see the `javadoc` of the interface `org.osc.sdk.manager.api.ApplianceManagerApi` defined by this SDK.
 
 ## OSC Manager Callback REST APIs
 


### PR DESCRIPTION
This PR updates the plugin development documentation mentioning the plugin properties and changing the existing code samples. The documentation does not include an extensive list of the required properties but instead directs the audience to the `javadoc` of the SDK. This will make it easier to keep this list up to date and accurate. 
**Note**: The `javadoc` is being updated by the PR opensecuritycontroller/security-mgr-api#7 and I will explicitly call out the required properties on the javadoc of the main interface of the plugin. 